### PR TITLE
Generalize a `with` function

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,13 +1,12 @@
 module Tests exposing (all, expectErr, isError, runWith)
 
 import Expect exposing (Expectation)
-import Json.Decode as Decode exposing (Decoder, null, string, succeed)
+import Json.Decode as Decode exposing (Decoder, at, field, null, string, succeed)
 import Json.Decode.Extra
     exposing
         ( default
         , defaultAt
-        , require
-        , requireAt
+        , with
         )
 import Test exposing (..)
 
@@ -42,64 +41,64 @@ all =
         "Json.Decode.Pipeline"
         [ test "should decode basic example" <|
             \() ->
-                (require "a" string <| \a ->
-                 require "b" string <| \b ->
+                (with (field "a" string) <| \a ->
+                 with (field "b" string) <| \b ->
                  succeed ( a, b )
                 )
                     |> runWith """{"a":"foo","b":"bar"}"""
                     |> Expect.equal (Ok ( "foo", "bar" ))
         , test "should decode requireAt fields" <|
             \() ->
-                (requireAt [ "a" ] string <| \a ->
-                 requireAt [ "b", "c" ] string <| \b ->
+                (with (at [ "a" ] string) <| \a ->
+                 with (at [ "b", "c" ] string) <| \b ->
                  succeed ( a, b )
                 )
                     |> runWith """{"a":"foo","b":{"c":"bar"}}"""
                     |> Expect.equal (Ok ( "foo", "bar" ))
         , test "should decode defaultAt fields" <|
             \() ->
-                (defaultAt [ "a", "b" ] string "--" <| \a ->
-                 defaultAt [ "x", "y" ] string "--" <| \b ->
+                (with (defaultAt [ "a", "b" ] string "--") <| \a ->
+                 with (defaultAt [ "x", "y" ] string "--") <| \b ->
                  succeed ( a, b )
                 )
                     |> runWith """{"a":{},"x":{"y":"bar"}}"""
                     |> Expect.equal (Ok ( "--", "bar" ))
         , test "default succeeds if the field is not present" <|
             \() ->
-                (default "a" string "--" <| \a ->
-                 default "x" string "--" <| \b ->
+                (with (default "a" string "--") <| \a ->
+                 with (default "x" string "--") <| \b ->
                  succeed ( a, b )
                 )
                     |> runWith """{"x":"five"}"""
                     |> Expect.equal (Ok ( "--", "five" ))
         , test "default succeeds with fallback if the field is present but null" <|
             \() ->
-                (default "a" string "--" <| \a ->
-                 default "x" string "--" <| \b ->
+                (with (default "a" string "--") <| \a ->
+                 with (default "x" string "--") <| \b ->
                  succeed ( a, b )
                 )
                     |> runWith """{"a":null,"x":"five"}"""
                     |> Expect.equal (Ok ( "--", "five" ))
         , test "default succeeds with result of the given decoder if the field is null and the decoder decodes nulls" <|
             \() ->
-                (default "a" (null "null") "--" <| \a ->
-                 default "x" string "--" <| \b ->
+                (with (default "a" (null "null") "--") <| \a ->
+                 with (default "x" string "--") <| \b ->
                  succeed ( a, b )
                 )
                     |> runWith """{"a":null,"x":"five"}"""
                     |> Expect.equal (Ok ( "null", "five" ))
         , test "default fails if the field is present but doesn't decode" <|
             \() ->
-                (default "a" string "--" <| \a ->
-                 default "x" string "--" <| \b ->
+                (with (default "a" string "--") <| \a ->
+                 with (default "x" string "--") <| \b ->
                  succeed ( a, b )
                 )
                     |> runWith """{"x":5}"""
                     |> expectErr
         , test "defaultAt fails if the field is present but doesn't decode" <|
             \() ->
-                (defaultAt [ "a", "b" ] string "--" <| \a ->
-                 defaultAt [ "x", "y" ] string "--" <| \b ->
+                (with (defaultAt [ "a", "b" ] string "--") <| \a ->
+                 with (defaultAt [ "x", "y" ] string "--") <| \b ->
                  succeed ( a, b )
                 )
                     |> runWith """{"a":{},"x":{"y":5}}"""


### PR DESCRIPTION
This is just a way of experimenting with an alternative approach to the API -- it's not a serious PR (unless you happen to like it).

As constructed, the API needs a separate function for each "base" decoder you'd want to use. For instance, `require` is basically equivalent to `field`, with a bit of extra behaviour attached.

What I wanted to experiment with was this: would it be possible to generalize the "extra behaviour" so that you wouldn't need a separate function for each base decoder. The result is the `with` function.

Using it, it is possible to avoid `require` and `requireAt` entirely. So, something like this:

```elm
userDecoder : Decoder User
userDecoder =
    require int "id" <| \id ->
    require int "followers" <| \followers ->
    require string "email" <| \email ->
    succeed { id = id, followers = followers, email = email }
```

... becomes something like this ...

```elm
userDecoder : Decoder User
userDecoder =
    with (field int "id") <| \id ->
    with (field int "followers") <| \followers ->
    with (field string "email") <| \email ->
    succeed { id = id, followers = followers, email = email }
```

The nice thing about this is that you can use the idiom without having a separate function for every base decoder. The not nice thing is that there are a few extra parentheses -- I experimented with a few ways of getting rid of them, but didn't succeed (at least, not yet).

It isn't possible to entirely get rid of `default` and `defaultAt`, because they have even more extra behaviour. However, their type signatures can be generalized, so that they can be used in even more contexts.

```elm
-- original
default : String -> Decoder a -> a -> (a -> Decoder b) -> Decoder b

-- generalized
default : String -> Decoder a -> a -> Decoder a
```

So, instead of something like this ...

```elm
userDecoder : Decoder User
userDecoder =
    require int "id" <| \id ->
    default 0 int "followers" <| \followers ->
    require string "email" <| \email ->
    succeed { id = id, followers = followers, email = email }
```

... you would have something like this ...

```elm
userDecoder : Decoder User
userDecoder =
    with (field int "id") <| \id ->
    with (default 0 int "followers") <| \followers ->
    with (field string "email") <| \email ->
    succeed { id = id, followers = followers, email = email }
```

I suppose that what I'm calling `with` here plays roughly the same role as what `Json.Decode.Pipeline` calls `custom`. So, you'd probably need something like this in a full API, even if you kept the more specific functions like `require` etc.

Anyway, this is just in the spirit of experimentation -- I'm not necessarily arguing that it's better.